### PR TITLE
permit custom certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,11 @@ If you want to use another name instead of 'wordpress' (http://url/wordpress), t
 
 	config setprop wordpress URL foldername
 	signal-event nethserver-wordpress-update
+
+If you've placed Wordpress in its own virtual host, and you want to use a separate TLS certificate (_i.e.,_ not the default server certificate) for that virtual host
+
+	config setprop wordpress CrtFile /path/to/certificate
+	config setprop wordpress ChainFile /path/to/chain
+	config setprop wordpress KeyFile /path/to/key
+	signal-event nethserver-wordpress-update
+

--- a/root/etc/e-smith/templates/etc/httpd/conf.d/zzz_wordpress.conf/10Conf
+++ b/root/etc/e-smith/templates/etc/httpd/conf.d/zzz_wordpress.conf/10Conf
@@ -11,8 +11,9 @@
     my $memorylimit = ($wordpress{'MemoryLimit'} || '128M');
     my $maxexecutiontime = ($wordpress{'MaxExecutionTime'} || '60');
     my $domain = $wordpress{'DomainName'} || '';
-    my $cert = $pki{'CrtFile'} || '/etc/pki/tls/certs/localhost.crt';
-    my $key = $pki{'KeyFile'} || '/etc/pki/tls/private/localhost.key';
+    my $cert = $wordpress{'CrtFile'} || '';
+    my $chain = $wordpress{'ChainFile'} || '';
+    my $key = $wordpress{'KeyFile'} || '';
 
       $OUT .= "#------------------------------------------------------------\n";
       $OUT .= "# wordpress  weblog\n";
@@ -41,9 +42,10 @@ elsif ($domain) {
     ServerName $domain
     SSLEngine on
     DocumentRoot  /usr/share/wordpress/
-    SSLCertificateFile "$cert"
-    SSLCertificateKeyFile "$key"
 EOF
+    $OUT .= "    SSLCertificateFile \"$cert\"\n" if ($cert ne '');
+    $OUT .= "    SSLCertificateChainFile \"$chain\"\n" if ($chain ne '');
+    $OUT .= "    SSLCertificateKeyFile \"$key\"\n" if ($key ne '');
 }
 
       $OUT .= "\n";


### PR DESCRIPTION
Resolves #8.

Update the Apache Virtual Host template to implement a config property for a unique TLS certificate for the Wordpress virtual host.  If this property isn't set, no cert is specified, and the virtual host will use the default server certificate. 